### PR TITLE
Allow use of illuminate\support @ 5.5.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "illuminate/support": "5.1.x|5.2.x|5.3.x|5.4.x",
+        "illuminate/support": "5.1.x|5.2.x|5.3.x|5.4.x|5.5.x",
         "symfony/console": "^2.7|^3.0",
         "symfony/http-kernel": "^2.7|^3.0",
         "barryvdh/laravel-stack-middleware": "^1.0"


### PR DESCRIPTION
Laravel 5.5 will be released, I was hoping to test this package out with it. I forked the project to do it myself, but discovered that the project https://github.com/barryvdh/laravel-stack-middleware also has the same requirements. I'm hoping you might update the requirements for these two projects.