### PR TITLE
Change function name from fire to handle on ClearCommand class

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -44,7 +44,7 @@ class ClearCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
 
         $cacheDir = $this->laravel['http_cache.cache_dir'];


### PR DESCRIPTION
Since 5.1 the Console Command has used handle() function instead of fire()