### PR TITLE
httpcache:clear updated

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -46,15 +46,19 @@ class ClearCommand extends Command
      */
     public function handle()
     {
-
         $cacheDir = $this->laravel['http_cache.cache_dir'];
 
-        if($this->files->cleanDirectory($cacheDir)){
-            $this->info('HttpCache cleared!');
-        }else{
-            $this->error('Could not clear HttpCache');
+        foreach ($this->files->glob("{$cacheDir}/*") as $directory) {
+            if (!$this->files->deleteDirectory($directory)) {
+                $errors = true;
+            }
         }
 
+        if (isset($errors)) {
+            $this->error('Could not clear HttpCache');
+        } else {
+            $this->info('HttpCache cleared!');
+        }
     }
 
 


### PR DESCRIPTION
httpcache:clear command changed to only delete the underlying directories in the httpcache storage folder.

This will allow a .gitignore file to be placed in the httpcache storage folder. I have not implemented that yet as the caching doesn't use FileSystem and I haven't read up on the Symfony HttpCache package.

As always this is just an suggestion