### PR TITLE
Request::isMethodSafe() is deprecated in Symfony 3.2

### DIFF
--- a/src/Middleware/SetTtl.php
+++ b/src/Middleware/SetTtl.php
@@ -18,7 +18,12 @@ class SetTtl
     {
         $response = $next($request);
 
-        if ($response instanceof Response && $request instanceof Request && $request->isMethodSafe()) {
+        if ($response instanceof Response && $request instanceof Request &&
+            (
+                (method_exists($request, 'isMethodCacheable') && $request->isMethodCacheable()) ||
+                (method_exists($request, 'isMethodSafe') && $request->isMethodSafe())
+            )
+        ) {
             $response->setTtl($seconds);
         }
 


### PR DESCRIPTION
One of the deprecations that Symfony 3.2 introduced, was Request::isMethodSafe(). We must now use Request::isMethodCacheable().